### PR TITLE
syntax/cs.vim: ignore missing syntax/xml.vim

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -101,7 +101,7 @@ syn cluster xmlTagHook add=csXmlTag
 
 syn match   csXmlCommentLeader	+\/\/\/+    contained
 syn match   csXmlComment	+\/\/\/.*$+ contains=csXmlCommentLeader,@csXml,@Spell
-syntax include @csXml syntax/xml.vim
+silent! syntax include @csXml syntax/xml.vim
 hi def link xmlRegion Comment
 
 


### PR DESCRIPTION
Some systems (e.g. msysgit) don't have syntax/xml.vim, but syntax highlighting works well enough without it.